### PR TITLE
Make "notifications" stand out a little more.

### DIFF
--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -14,6 +14,8 @@ $link: $linkcolor;
 $link-active: $maincolor;
 $body-size: 20px;
 
+$notification-background-color: hsl(60, 100%, 96%);
+
 // Import the rest of Bulma
 @import "./assets/styles/bulma/bulma.sass";
 


### PR DESCRIPTION
Especially looking at #32, where a "notification" (which we use as hints) follows directly after a code-block, both of which where gray up to now.